### PR TITLE
added version key to avoid error in logs

### DIFF
--- a/custom_components/sql_json/manifest.json
+++ b/custom_components/sql_json/manifest.json
@@ -6,5 +6,6 @@
   "requirements": ["sqlalchemy==1.3.19"],
   "dependencies": [],
   "after_dependencies": ["recorder"],
-  "codeowners": ["@dgomes", "@crowbarz"]
+  "codeowners": ["@dgomes", "@crowbarz"],
+  "version": "1.0"
 }


### PR DESCRIPTION
```
No 'version' key in the manifest file for custom integration 'sql_json'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'sql_json'
```